### PR TITLE
handled the error in Promises

### DIFF
--- a/src/helpers/clickHandler.js
+++ b/src/helpers/clickHandler.js
@@ -31,21 +31,25 @@ export const clickHandler = function (stateUpdater) {
         // inside the async function
         const target = event.target;
 
-        getAudioFromClick(target).play()
-            .then(function () {
+        const playPromise = getAudioFromClick(target).play();
+
+        if (playPromise !== undefined) {
+            playPromise.then(function () {
                 const dp = getAudioFromClick(target).parentElement;
 
                 dp.style.backgroundColor = activeBackground;
                 dp.style.border = activeBorder;
 
                 return dp;
-            })
-            .then(function (drumpad) {
+            }).then(function (drumpad) {
                 setTimeout(function () {
                     drumpad.style.backgroundColor = inactiveBackground;
                     drumpad.style.border = inactiveBorder;
                 }, 200);
+            }).catch(function (error) {
+                console.error(error);
             });
+        }
         stateUpdater(event.target.textContent);
     };
 };

--- a/src/helpers/keyHandler.js
+++ b/src/helpers/keyHandler.js
@@ -31,21 +31,27 @@ export const keyHandler = function (stateUpdater) {
             return;
         }
 
-        getAudioFromKey(event.key).play()
-            .then(function () {
+        //getAudioFromKey(event.key).load();
+
+        const playPromise = getAudioFromKey(event.key).play();
+
+        if (playPromise !== undefined) {
+            playPromise.then(function () {
                 const dp = getDrumpadFromKey(event.key);
 
                 dp.style.backgroundColor = activeBackground;
                 dp.style.border = activeBorder;
 
                 return dp;
-            })
-            .then(function (drumpad) {
+            }).then(function (drumpad) {
                 setTimeout(function () {
                     drumpad.style.backgroundColor = inactiveBackground;
                     drumpad.style.border = inactiveBorder;
                 }, 200);
-            })
+            }).catch(function (error) {
+                console.error(error);
+            });
+        }
         stateUpdater(event.key.toUpperCase());
     };
 };


### PR DESCRIPTION
The [error documented here](https://developers.google.com/web/updates/2017/06/play-request-was-interrupted) is caused when an `HTMLMediaElement` is played and then paused.

In the app, this error is caused by FreeCodeCamp's test suite script. That means the error cannot be avoided, but it can be handled. 

In both event handler files, you will see there was added a `catch` clause. Now the error is shown as a message in the console, but it doesn't make the FCC test suite to throw an error