### PR TITLE
changed media query in footer styles

### DIFF
--- a/src/scss/layout/_footer.scss
+++ b/src/scss/layout/_footer.scss
@@ -27,7 +27,7 @@ footer {
 footer > p {
     display: none;
 
-    @include create-media-query(min-width, --small-breakpoint) {
+    @include create-media-query(min-width, --medium-breakpoint) {
         /* layout rules */
         display:block;
         margin-top: 1rem;


### PR DESCRIPTION
The instructions in the footer were not displayed correctly. 

I gave another breakpoint to the media query in the `_footer.scss` to avoid it, as you can see in the [commit d841842](https://github.com/rafael-atias/fcc-drum-machine/commit/d84184266cf2b897fb3b1bbd847d8ea079c7547b ).