### PR TITLE
corrected import path in _vendors.scss file

### DIFF
--- a/src/scss/vendors/_vendors.scss
+++ b/src/scss/vendors/_vendors.scss
@@ -1,2 +1,2 @@
-@import "scss/vendors/_normalize.scss";
-@import "scss/vendors/_fcc-test-bundle.scss";
+@import "./_normalize.scss";
+@import "./_fcc-test-bundle.scss";


### PR DESCRIPTION
The error was caused because the `@import` rule takes as a reference the same file where it is used.

This caused errors when trying to build the app.