### PR TITLE
deleted fcc-bundle

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -23,18 +23,5 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
 </body>
-<script>
-  window.addEventListener("load", function () {
-    const bundle = document.createElement("script");
-    bundle.defer = true;
-
-    bundle.src = new URL("https://cdn.freecodecamp.org/testable-projects-fcc/v1/bundle.js");
-
-    document.body.appendChild(bundle);
-  }, {
-    once: true,
-    passive: true
-  });
-</script>
 
 </html>


### PR DESCRIPTION
The script tag with the fcc bundle code was deleted from `public/index.html` to make the project look more professional to possible employers